### PR TITLE
fix-calculate-line-for-triangles

### DIFF
--- a/Geometries/Contours_from_NetCDF/conrec.py
+++ b/Geometries/Contours_from_NetCDF/conrec.py
@@ -64,95 +64,95 @@ def conrec(data,x,y,levels,format="PYTHON"):
                                 sh[m]=-1
                             else:
                                 sh[m]=0
-                    #     Note: at this stage the relative heights of the corners and the
-                    #c     centre are in the h array, and the corresponding coordinates are
-                    #c     in the xh and yh arrays. The centre of the box is indexed by 0
-                    #c     and the 4 corners by 1 to 4 as shown below.
-                    #c     Each triangle is then indexed by the parameter m, and the 3
-                    #c     vertices of each triangle are indexed by parameters m1,m2,and m3.
-                    #c     It is assumed that the centre of the box is always vertex 2 though
-                    #c     this isimportant only when all 3 vertices lie exactly on the same
-                    #c     contour level, in which case only the side of the box is drawn.
-                    #c
-                    #c
-                    #c           vertex 4 +-------------------+ vertex 3
-                    #c                    | \               / |
-                    #c                    |   \    m-3    /   |
-                    #c                    |     \       /     |
-                    #c                    |       \   /       |
-                    #c                    |  m=2    X   m=2   |       the centre is vertex 0
-                    #c                    |       /   \       |
-                    #c                    |     /       \     |
-                    #c                    |   /    m=1    \   |
-                    #c                    | /               \ |
-                    #c           vertex 1 +-------------------+ vertex 2
-                    #c
-                    #c
-                    #c
-                    #c                    Scan each triangle in the box
-                    for m in range(1,5):
-                        m1=m
-                        m2=0
-                        if(m != 4):
-                            m3=m+1
-                        else:
-                            m3=1
-                        case = castab[ sh[m1]+1][ sh[m2]+1 ][ sh[m3]+1 ]
-                        if (case==1):
-                            x1 = xh[m1];
-                            y1 = yh[m1];
-                            x2 = xh[m2];
-                            y2 = yh[m2];
-                        elif (case==2):
-                            #case 2: /* Line between vertices 2 and 3 */
-                            x1 = xh[m2];
-                            y1 = yh[m2];
-                            x2 = xh[m3];
-                            y2 = yh[m3];
-                        elif (case==3):
-                            # case 3: /* Line between vertices 3 and 1 */
-                            x1 = xh[m3];
-                            y1 = yh[m3];
-                            x2 = xh[m1];
-                            y2 = yh[m1];
-                        elif (case==4):
-                            #case 4: /* Line between vertex 1 and side 2-3 */
-                            x1 = xh[m1];
-                            y1 = yh[m1];
-                            x2 = xsect(m2,m3);
-                            y2 = ysect(m2,m3);
-                        elif (case==5):
-                            #case 5: /* Line between vertex 2 and side 3-1 */
-                            x1 = xh[m2];
-                            y1 = yh[m2];
-                            x2 = xsect(m3,m1);
-                            y2 = ysect(m3,m1);
-                        elif (case==6):
-                            # case 6: /* Line between vertex 3 and side 1-2 */
-                            x1 = xh[m3];
-                            y1 = yh[m3];
-                            x2 = xsect(m1,m2);
-                            y2 = ysect(m1,m2);
-                        elif (case==7):
-                            # case 7: /* Line between sides 1-2 and 2-3 */
-                            x1 = xsect(m1,m2);
-                            y1 = ysect(m1,m2);
-                            x2 = xsect(m2,m3);
-                            y2 = ysect(m2,m3);
-                        elif (case==8):
-                            # case 8: /* Line between sides 2-3 and 3-1 */
-                            x1 = xsect(m2,m3);
-                            y1 = ysect(m2,m3);
-                            x2 = xsect(m3,m1);
-                            y2 = ysect(m3,m1);
-                        elif (case==9):
-                            #case 9: /* Line between sides 3-1 and 1-2 */
-                            x1 = xsect(m3,m1);
-                            y1 = ysect(m3,m1);
-                            x2 = xsect(m1,m2);
-                            y2 = ysect(m1,m2);
-                        if (case !=0 ):
-                            allpoints.append([[x1,y1],[x2,y2],level])
+                        #     Note: at this stage the relative heights of the corners and the
+                        #c     centre are in the h array, and the corresponding coordinates are
+                        #c     in the xh and yh arrays. The centre of the box is indexed by 0
+                        #c     and the 4 corners by 1 to 4 as shown below.
+                        #c     Each triangle is then indexed by the parameter m, and the 3
+                        #c     vertices of each triangle are indexed by parameters m1,m2,and m3.
+                        #c     It is assumed that the centre of the box is always vertex 2 though
+                        #c     this isimportant only when all 3 vertices lie exactly on the same
+                        #c     contour level, in which case only the side of the box is drawn.
+                        #c
+                        #c
+                        #c           vertex 4 +-------------------+ vertex 3
+                        #c                    | \               / |
+                        #c                    |   \    m-3    /   |
+                        #c                    |     \       /     |
+                        #c                    |       \   /       |
+                        #c                    |  m=2    X   m=2   |       the centre is vertex 0
+                        #c                    |       /   \       |
+                        #c                    |     /       \     |
+                        #c                    |   /    m=1    \   |
+                        #c                    | /               \ |
+                        #c           vertex 1 +-------------------+ vertex 2
+                        #c
+                        #c
+                        #c
+                        #c                    Scan each triangle in the box
+                        for m in range(1,5):
+                            m1=m
+                            m2=0
+                            if(m != 4):
+                                m3=m+1
+                            else:
+                                m3=1
+                            case = castab[ sh[m1]+1][ sh[m2]+1 ][ sh[m3]+1 ]
+                            if (case==1):
+                                x1 = xh[m1];
+                                y1 = yh[m1];
+                                x2 = xh[m2];
+                                y2 = yh[m2];
+                            elif (case==2):
+                                #case 2: /* Line between vertices 2 and 3 */
+                                x1 = xh[m2];
+                                y1 = yh[m2];
+                                x2 = xh[m3];
+                                y2 = yh[m3];
+                            elif (case==3):
+                                # case 3: /* Line between vertices 3 and 1 */
+                                x1 = xh[m3];
+                                y1 = yh[m3];
+                                x2 = xh[m1];
+                                y2 = yh[m1];
+                            elif (case==4):
+                                #case 4: /* Line between vertex 1 and side 2-3 */
+                                x1 = xh[m1];
+                                y1 = yh[m1];
+                                x2 = xsect(m2,m3);
+                                y2 = ysect(m2,m3);
+                            elif (case==5):
+                                #case 5: /* Line between vertex 2 and side 3-1 */
+                                x1 = xh[m2];
+                                y1 = yh[m2];
+                                x2 = xsect(m3,m1);
+                                y2 = ysect(m3,m1);
+                            elif (case==6):
+                                # case 6: /* Line between vertex 3 and side 1-2 */
+                                x1 = xh[m3];
+                                y1 = yh[m3];
+                                x2 = xsect(m1,m2);
+                                y2 = ysect(m1,m2);
+                            elif (case==7):
+                                # case 7: /* Line between sides 1-2 and 2-3 */
+                                x1 = xsect(m1,m2);
+                                y1 = ysect(m1,m2);
+                                x2 = xsect(m2,m3);
+                                y2 = ysect(m2,m3);
+                            elif (case==8):
+                                # case 8: /* Line between sides 2-3 and 3-1 */
+                                x1 = xsect(m2,m3);
+                                y1 = ysect(m2,m3);
+                                x2 = xsect(m3,m1);
+                                y2 = ysect(m3,m1);
+                            elif (case==9):
+                                #case 9: /* Line between sides 3-1 and 1-2 */
+                                x1 = xsect(m3,m1);
+                                y1 = ysect(m3,m1);
+                                x2 = xsect(m1,m2);
+                                y2 = ysect(m1,m2);
+                            if (case !=0 ):
+                                allpoints.append([[x1,y1],[x2,y2],level])
     EPSILON = 1.0e-15 ## Zero distance between points = below numerical error
     def dist(p1,p2):
         return math.sqrt( (p1[0]-p2[0])**2 + (p1[1]-p2[1])**2 )


### PR DESCRIPTION
fixed for loop for calculating the line of each triangle. Now there are only the wanted lines calculated like in the original conrec algorithm from Paul Borke. More details are in the [issue](https://github.com/fercook/SciViz/issues/3)